### PR TITLE
llms.txt workflow

### DIFF
--- a/.github/workflows/commit-llms-txt.yml
+++ b/.github/workflows/commit-llms-txt.yml
@@ -1,0 +1,58 @@
+---
+name: Commit llms.txt
+on:
+  workflow_run:
+    workflows: ["Generate llms.txt"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  commit:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download llms.txt artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: llms-txt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          echo "pr_number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+          echo "pr_branch=$(cat pr-branch.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.pr_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy generated llms.txt
+        uses: actions/download-artifact@v4
+        with:
+          name: llms-txt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: .artifact
+
+      - name: Commit llms.txt if changed
+        run: |
+          cp .artifact/src/pages/llms.txt src/pages/llms.txt
+          rm -rf .artifact
+
+          git add src/pages/llms.txt
+          if git diff --staged --quiet; then
+            echo "No changes to llms.txt, skipping commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "auto-generate llms.txt"
+          git push

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -1,0 +1,42 @@
+---
+name: Generate llms.txt
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/pages/**'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate llms.txt
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            execSync('npm install --no-save github:AdobeDocs/adp-devsite-scripts', { stdio: 'inherit' });
+            const generate = require('./node_modules/adp-devsite-scripts/llm-txt-generate/generate-llms-txt.js');
+            await generate({ core });
+
+      - name: Save PR metadata
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "${{ github.event.pull_request.head.ref }}" > pr-branch.txt
+
+      - name: Upload llms.txt artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llms-txt
+          path: |
+            src/pages/llms.txt
+            pr-number.txt
+            pr-branch.txt


### PR DESCRIPTION
Added two GitHub Actions workflows that automatically generate and commit an llms.txt file whenever content under src/pages/ changes in a PR. This follows the [llms.txt standard](https://llmstxt.org/) to make our documentation discoverable by LLMs. Similar to other PR writing bot, these workflows use artifact to pass through the generated documents and PR credentials for security and private repo permission concerns in PR created by forked repo.

## generate-llms-txt.yml
- download the llms-txt-generator scripts from scripts repo
- run the generator to generate llms.txt
- passes llms.txt and PR related info to commit-llms-txt.yml

## commit-llms-txt.yml
- get the data from artifact
- push the generated txt with an additional commit to the PR who triggered these 2 workflow