### PR TITLE
feat: add --prefer-online to all npx scripts to ensure latest adp-devsite-utils is always used

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
     "node": "^24.11.0"
   },
   "scripts": {
-    "dev": "npx --yes github:AdobeDocs/adp-devsite-utils dev",
-    "buildNavigation": "npx --yes github:AdobeDocs/adp-devsite-utils buildNavigation -v",
-    "buildRedirections": "npx --yes github:AdobeDocs/adp-devsite-utils buildRedirections -v",
-    "renameFiles": "npx --yes github:AdobeDocs/adp-devsite-utils renameFiles -v",
-    "normalizeLinks": "npx --yes github:AdobeDocs/adp-devsite-utils normalizeLinks -v",
-    "buildSiteWideBanner": "npx --yes github:AdobeDocs/adp-devsite-utils buildSiteWideBanner -v",
-    "buildSiteMetadata": "npx --yes github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v",
-    "buildContributors": "npx --yes github:AdobeDocs/adp-devsite-utils buildContributorsV2 -v",
-    "lint": "npx --yes github:AdobeDocs/adp-devsite-utils runLint -v",
-    "lint:errorOnly": "npx --yes github:AdobeDocs/adp-devsite-utils runLint",
-    "link:externalLinkOnly": "npx --yes github:AdobeDocs/adp-devsite-utils runLint --external-links-only -v",
-    "link:checkAllLinks": "npx --yes github:AdobeDocs/adp-devsite-utils runLint --internal-links-only --external-links-only -v",
-    "redirectCheck:stage": "npx --yes github:AdobeDocs/adp-devsite-utils redirectChecker stage --verbose",
-    "redirectCheck:prod": "npx --yes github:AdobeDocs/adp-devsite-utils redirectChecker prod --verbose"
+    "dev": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils dev",
+    "buildNavigation": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils buildNavigation -v",
+    "buildRedirections": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils buildRedirections -v",
+    "renameFiles": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils renameFiles -v",
+    "normalizeLinks": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils normalizeLinks -v",
+    "buildSiteWideBanner": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils buildSiteWideBanner -v",
+    "buildSiteMetadata": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils buildSiteMetadata -v",
+    "buildContributors": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils buildContributorsV2 -v",
+    "lint": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils runLint -v",
+    "lint:errorOnly": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils runLint",
+    "link:externalLinkOnly": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils runLint --external-links-only -v",
+    "link:checkAllLinks": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils runLint --internal-links-only --external-links-only -v",
+    "redirectCheck:stage": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils redirectChecker stage --verbose",
+    "redirectCheck:prod": "npx --yes --prefer-online github:AdobeDocs/adp-devsite-utils redirectChecker prod --verbose"
   }
 }


### PR DESCRIPTION
## Description
Adds `--prefer-online` to all `npx` scripts in package.json so local runs always use the latest version of `adp-devsite-utils`, matching what GH Actions pulls. Prevents stale cache causing discrepancies between local and CI lint results.

## Slack
- https://adobeio.slack.com/archives/GTSGK6807/p1778515439207479?thread_ts=1778514950.696109&cid=GTSGK6807
- https://adobeio.slack.com/archives/C06M1C7UBV3/p1778516571313329

## Test
<img width="765" height="616" alt="Screenshot 2026-05-11 at 9 39 05 AM" src="https://github.com/user-attachments/assets/97eb579a-d8c4-4f65-a892-0fc00e07f76e" />
