### PR TITLE
update lint.yml to check change in src/Pages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,6 @@ name: Lint
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'src/pages/**'
 
 jobs:
   lint:
@@ -12,9 +10,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for src/pages changes
+        id: changes
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^src/pages/' \
+            && echo "changed=true" >> $GITHUB_OUTPUT \
+            || echo "changed=false" >> $GITHUB_OUTPUT
 
       - name: Lint
         id: lint
+        if: steps.changes.outputs.changed == 'true'
         continue-on-error: true
         run: npx --yes github:AdobeDocs/adp-devsite-utils runLint -v
 
@@ -30,7 +38,8 @@ jobs:
           path: |
             linter-report.txt
             pr-number.txt
+          if-no-files-found: ignore
 
       - name: Fail if linter found errors
-        if: steps.lint.outcome == 'failure'
+        if: steps.changes.outputs.changed == 'true' && steps.lint.outcome == 'failure'
         run: exit 1


### PR DESCRIPTION
## Problem
If the repo owner set a branch ruleset about linter saying lint.yml is a required status check to merge the PR, and if the PR does not involve a change in src/Pages, the status checker will wait for lint.yml forever.

## Verification
same code change on commit https://github.com/AdobeDocs/adp-devsite-github-actions-test/commit/e0a2cb330c1ebc98e638086b472d50ec0a1390da. To test it, close and reopen this [test PR](https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/129), the branch ruleset will point out that lint.yml is a required check, then wait for a min, the status checker will report the lint check is passed
