### PR TITLE
feat: simultaneous private deploys

### DIFF
--- a/.github/workflows/deploy-private.yml
+++ b/.github/workflows/deploy-private.yml
@@ -5,12 +5,21 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      env:
+        description: "Select environment to deploy to"
+        type: choice
+        required: true
+        default: "prod"
+        options:
+          - "prod"
+          - "stage & prod"
 
 jobs:
   deployment:
     name: Deployment
     if: github.actor != 'adp-devsite-app[bot]' && github.repository != 'AdobeDocs/dev-docs-template'
-    uses: AdobeDocsPrivate/adp-devsite-workflow-private/.github/workflows/deploy-v2.yml@main
+    uses: AdobeDocsPrivate/adp-devsite-workflow-private/.github/workflows/deploy-v3.yml@main
     secrets: inherit
     with:
-      env: prod
+      env: ${{ inputs.env || 'prod' }}

--- a/.github/workflows/stage-private.yml
+++ b/.github/workflows/stage-private.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deployment:
     name: Deployment
-    uses: AdobeDocsPrivate/adp-devsite-workflow-private/.github/workflows/deploy-v2.yml@main
+    uses: AdobeDocsPrivate/adp-devsite-workflow-private/.github/workflows/deploy-v3.yml@main
     secrets: inherit
     with:
-      env: stg
+      env: stage


### PR DESCRIPTION
## Description

Accompanies AdobeDocsPrivate/adp-devsite-workflow-private#10

Adds `"stage & prod"` option to deploy both environments in parallel via `deploy-v3.yml`.

## Screenshot
<img width="1494" height="855" alt="Screenshot 2026-06-23 at 3 38 51 PM" src="https://github.com/user-attachments/assets/8824084d-4242-494e-ba50-125cea747790" />

## Before Merging
1. Merge AdobeDocsPrivate/adp-devsite-workflow-private#10
2. Get [greenlight for v3](https://jira.corp.adobe.com/browse/DEVSITE-2439?focusedId=55641362&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-55641362)
