### PR TITLE
feat: render RedoclyAPIBlock examples in full-page layout

### DIFF
--- a/src/pages/api/1-4.md
+++ b/src/pages/api/1-4.md
@@ -1,1 +1,5 @@
+---
+layout: none
+--- 
+
 <RedoclyAPIBlock src="/dev-docs-template/petstore.json" />

--- a/src/pages/api/index.md
+++ b/src/pages/api/index.md
@@ -1,1 +1,5 @@
+---
+layout: none
+--- 
+
 <RedoclyAPIBlock src="/dev-docs-template/petstore.json" />


### PR DESCRIPTION
Update the template so RedoclyAPIBlock examples use the full page width. Most teams already implement this, making it a sensible default configuration, e.g.: https://github.com/AdobeDocs/adobe-io-events/blob/main/src/pages/api.md?plain=1#L2